### PR TITLE
return 206 when start <= size < stop

### DIFF
--- a/ranged_fileresponse/__init__.py
+++ b/ranged_fileresponse/__init__.py
@@ -129,9 +129,11 @@ class RangedFileResponse(FileResponse):
         # multipart byteranges).
         if ranges is not None and len(ranges) == 1:
             start, stop = ranges[0]
-            if stop > size:
+            if start > size:
                 # Requested range not satisfiable.
                 return HttpResponse(status=416)
+            if stop > size:
+                stop = size
             self.ranged_file.start = start
             self.ranged_file.stop = stop
             self['Content-Range'] = 'bytes %d-%d/%d' % (start, stop - 1, size)


### PR DESCRIPTION
In <https://tools.ietf.org/html/rfc7233#section-4.4>
```
   The 416 (Range Not Satisfiable) status code indicates that none of
   the ranges in the request's Range header field (Section 3.1) overlap
   the current extent of the selected resource or that the set of ranges
   requested has been rejected due to invalid ranges or an excessive
   request of small or overlapping ranges.

   For byte ranges, failing to overlap the current extent means that the
   first-byte-pos of all of the byte-range-spec values were greater than
   the current length of the selected representation.  When this status
   code is generated in response to a byte-range request, the sender
   SHOULD generate a Content-Range header field specifying the current
   length of the selected representation (Section 4.2).
```