### PR TITLE
Added file object to '_closable_objects' to close at end of request

### DIFF
--- a/ranged_fileresponse/__init__.py
+++ b/ranged_fileresponse/__init__.py
@@ -107,6 +107,9 @@ class RangedFileResponse(FileResponse):
         """
         self.ranged_file = RangedFileReader(file)
         super(RangedFileResponse, self).__init__(self.ranged_file, *args, **kwargs)
+        # Close file object at end of request
+        if hasattr(file, 'close') and hasattr(self, '_closable_objects'):
+            self._closable_objects.append(file)
 
         if 'HTTP_RANGE' in request.META:
             self.add_range_headers(request.META['HTTP_RANGE'])


### PR DESCRIPTION
This commit fixes ResourceWarnings in Python 3 where file objects do not appear to be closed at the end of the request, and the Django server will emit ResourceWarnings about unclosed files.

The `_closable_objects` list is managed by the base FileResponse class in Django and will call `.close()` on objects at the end of the request.

### Issue number

N/A

### Expected behaviour

File object would be closed at the end of the request.

### Actual behaviour

File object remains open.

### Description of fix

The `FileResponse` object maintains a list of objects to be closed at the end of the request.  Since this class uses a special reader class the file object is not appended to.  This will add the file object when the instance is created.  Checks to ensure file object has a `close()` method, and that the `FileResponse` class has the `_closable_object` property (for compatibility).

### Other info

Was causing intermittent warnings/crashes in the Django runserver when `--autoreload` used.

