### PR TITLE
Automatically close underlying file object when response closes

### DIFF
--- a/ranged_fileresponse/__init__.py
+++ b/ranged_fileresponse/__init__.py
@@ -107,6 +107,9 @@ class RangedFileResponse(FileResponse):
         """
         self.ranged_file = RangedFileReader(file)
         super(RangedFileResponse, self).__init__(self.ranged_file, *args, **kwargs)
+        # Close file object at end of request
+        if hasattr(file, 'close') and hasattr(self, '_closable_objects'):
+            self._closable_objects.append(file)
 
         if 'HTTP_RANGE' in request.META:
             self.add_range_headers(request.META['HTTP_RANGE'])

--- a/ranged_fileresponse/__init__.py
+++ b/ranged_fileresponse/__init__.py
@@ -19,7 +19,6 @@ class RangedFileReader(object):
             block_size (Optional[int]): The block_size to read with.
         """
         self.f = file_like
-        
         # If size property available (ie: Django File, FieldFile, etc) and not zero (if zero, double-check anyway)
         if hasattr(self.f, 'size') and self.f.size > 0:
             self.size = self.f.size
@@ -98,12 +97,13 @@ class RangedFileReader(object):
         if hasattr(self.f, 'close'):
             self.f.close()
 
+
 class RangedFileResponse(FileResponse):
     """
     This is a modified FileResponse that returns `Content-Range` headers with
     the response, so browsers that request the file, can stream the response
     properly.
-    
+
     Note: When using RangedFileResponse with django tests, make sure to read the response.streaming_content after the
     request, otherwise the underlying file won't be auto-closed.
     """

--- a/ranged_fileresponse/__init__.py
+++ b/ranged_fileresponse/__init__.py
@@ -119,10 +119,6 @@ class RangedFileResponse(FileResponse):
         """
         self.ranged_file = RangedFileReader(file)
         super(RangedFileResponse, self).__init__(self.ranged_file, *args, **kwargs)
-        # Close file object at end of request
-        if hasattr(file, 'close') and hasattr(self, '_closable_objects'):
-            self._closable_objects.append(file)
-
         if 'HTTP_RANGE' in request.META:
             self.add_range_headers(request.META['HTTP_RANGE'])
 

--- a/ranged_fileresponse/__init__.py
+++ b/ranged_fileresponse/__init__.py
@@ -19,7 +19,12 @@ class RangedFileReader(object):
             block_size (Optional[int]): The block_size to read with.
         """
         self.f = file_like
-        self.size = len(self.f.read())
+        
+        # If size property available (ie: Django File, FieldFile, etc) and not zero (if zero, double-check anyway)
+        if hasattr(self.f, 'size') and self.f.size > 0:
+            self.size = self.f.size
+        else:
+            self.size = len(self.f.read())
         self.block_size = block_size or RangedFileReader.block_size
         self.start = start
         self.stop = stop
@@ -88,12 +93,19 @@ class RangedFileReader(object):
 
         return ranges
 
+    def close(self):
+        """Close underlying file object"""
+        if hasattr(self.f, 'close'):
+            self.f.close()
 
 class RangedFileResponse(FileResponse):
     """
     This is a modified FileResponse that returns `Content-Range` headers with
     the response, so browsers that request the file, can stream the response
     properly.
+    
+    Note: When using RangedFileResponse with django tests, make sure to read the response.streaming_content after the
+    request, otherwise the underlying file won't be auto-closed.
     """
 
     def __init__(self, request, file, *args, **kwargs):


### PR DESCRIPTION
### Expected behaviour

Underlying file object should get closed when the response gets closed. The underlying `StreamingHttpResponse` should add the `RangedFileReader` to the `_closable_objects` list.

### Actual behaviour

Without a `RangedFileReader.close()` method, the `StreamingHttpResponse` doesn't see the `RangedFileReader` (and its underlying file) as a closable object.

### Description of fix

- Added RangedFileReader.close() method, which allows underlying StreamingHttpResponse to add to `_closable_objects`.
- Also initialized `RangedFileReader.size` using `file_like.size` property (if available, i.e. Django File/FieldFile) rather than reading entire file contents.

This supercedes the changes in https://github.com/wearespindle/django-ranged-fileresponse/pull/11