### PR TITLE
Include LICENSE in sdist and wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
 [flake8]
 max-line-length = 119
 ignore = C901
+
+[metadata]
+license_files = LICENSE


### PR DESCRIPTION
This includes the LICENSE file in the package distributions and avoids that we need to copy it if we packages this for a distribution, e.g. for conda-forge: https://github.com/conda-forge/staged-recipes/pull/21095